### PR TITLE
Update window() docs

### DIFF
--- a/library/windows.lua
+++ b/library/windows.lua
@@ -19,6 +19,11 @@ function set_draw_target(ud) end
 function get_draw_target() end
 
 ---@class window
+---@field x? number                --  x position in pixels
+---@field y? number                --  y position in pixels
+---@field dx? number               --  x-offset to move the window
+---@field dy? number               --  y-offset to move the window
+---@field z? number                --  windows with higher z are drawn on top. Defaults to 0
 ---@field width? number            --  width in pixels (not including the frame)
 ---@field height? number           --  height in pixels
 ---@field title? string            --  set a title displayed on the window's titlebar
@@ -29,13 +34,17 @@ function get_draw_target() end
 ---@field resizeable? boolean      --  default: true
 ---@field wallpaper? boolean       --  act as a wallpaper (z defaults to -1000 in that case)
 ---@field autoclose? boolean       --  close window when is no longer in focus or when press escape
----@field z? number                --  windows with higher z are drawn on top. Defaults to 0
 ---@field cursor? number|userdata  --  0 for no cursor, 1 for default, or a userdata for a custom cursor
 
 ---Create a window and/or set the window's attributes.
 ---
 ---attribs is table of desired attributes for the window.
 ---```
+---x          --  x position in pixels
+---y          --  y position in pixels
+---dx         --  x-offset to move the window
+---dy         --  y-offset to move the window
+---z          --  windows with higher z are drawn on top. Defaults to 0
 ---width      --  width in pixels (not including the frame)
 ---height     --  height in pixels
 ---title      --  set a title displayed on the window's titlebar
@@ -46,7 +55,6 @@ function get_draw_target() end
 ---resizeable --  default: true
 ---wallpaper  --  act as a wallpaper (z defaults to -1000 in that case)
 ---autoclose  --  close window when is no longer in focus or when press escape
----z          --  windows with higher z are drawn on top. Defaults to 0
 ---cursor     --  0 for no cursor, 1 for default, or a userdata for a custom cursor
 ---squashable --  window resizes itself to stay within the desktop region
 ---```

--- a/library/windows.lua
+++ b/library/windows.lua
@@ -67,7 +67,8 @@ function window(attribs) end
 ---[View Online](https://www.lexaloffle.com/dl/docs/picotron_manual.html#window)
 ---@param width number
 ---@param height number
-function window(width, height) end
+---@param attribs? window
+function window(width, height, attribs) end
 
 ---Set a fullscreen video mode. Currently supported modes:
 ---- vid(0): 480x270


### PR DESCRIPTION
- Add `x`, `y`, `dx`, `dy` to `window()` attributes
- Add `attribs` to `window(w,h)` function

Uncovered from Zep's source (`/system/lib/head.lua`):
```lua
function window(w, h, attribs)

-- this function wrangles parameters;
-- set_window_1 doesn't do any further transformation / validation on parameters

if (type(w) == "table") then
	attribs = w
	w,h = nil,nil

	-- special case: adjust position by dx, dy
	-- discard other 
	if (attribs.dx or attribs.dy) then
		_send_message(3, {event="move_window", dx=attribs.dx, dy=attribs.dy})
		return
	end

end

attribs = attribs or {}
attribs.width = attribs.width or w
attribs.height = attribs.height or h

return set_window_1(attribs)
end
```