### PR TITLE
Enable "basic" builtin in order to provide "tostring" definition.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
         ">>="
     ],
     "Lua.runtime.builtin": {
-        "basic": "disable",
+        "basic": "enable",
         "bit": "disable",
         "bit32": "disable",
         "builtin": "disable",

--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
             ">>="
         ],
         "Lua.runtime.builtin": {
-            "basic": "disable",
+            "basic": "enable",
             "bit": "disable",
             "bit32": "disable",
             "builtin": "disable",


### PR DESCRIPTION
I have a following debug helper code in my Picotron project:

```lua
---@type string[]
local dbg_lines = {}

---@param val any
function dbg(val)
    add(dbg_lines, tostring(val))
end
```

With `runtime.builtin.basic` configured to `disable` I get a warning in VS Code:

```
Undefined global `tostring`.
```

<img width="600"  alt="screenshot 2025-10-02 at 11 51 53" src="https://github.com/user-attachments/assets/0168f0bb-494e-4366-9732-ce2405a2cd4b" />

I am not sure if this PR is correct, I mean if it doesn't bring too much definitions into the table.
