### PR TITLE
Enable "math" builtin in order to provide "math.tointeger" definition.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,7 @@
         "ffi": "disable",
         "io": "disable",
         "jit": "disable",
-        "math": "disable",
+        "math": "enable",
         "os": "disable",
         "package": "disable",
         "string": "disable",

--- a/config.json
+++ b/config.json
@@ -31,7 +31,7 @@
             "ffi": "disable",
             "io": "disable",
             "jit": "disable",
-            "math": "disable",
+            "math": "enable",
             "os": "disable",
             "package": "disable",
             "string": "disable",


### PR DESCRIPTION
I have a code like this:

```lua
---@return table<string, boolean>
---@nodiscard
function Level:_get_tiles_close_to_player()
    local margin = 3
    local left_top = vec(
        flr(self._player:xy1().x / g.ts),
        flr(self._player:xy1().y / g.ts)
    ) + 1 - margin
    local right_bottom = vec(
        flr(self._player:xy2().x / g.ts),
        flr(self._player:xy2().y / g.ts)
    ) + 1 + margin

    ---@type table<string, boolean>
    local close_tiles = {}
    for tx = left_top.x, right_bottom.x do
        for ty = left_top.y, right_bottom.y do
            close_tiles[math.tointeger(tx) .. "_" .. math.tointeger(ty)] = true
        end
    end
    return close_tiles
end
```

and the `math.tointeger` was producing a warning about not being defined:

<img width="600"  alt="screenshot 2025-10-02 at 11 58 50" src="https://github.com/user-attachments/assets/a3d0590c-0826-43db-bb7c-443230d806e0" />

But please be aware I have no idea if it is OK to enable entire `math` builtin in Picotron or does it just happen to support than single function :)