### PR TITLE
Enable "string" builtin in order to provide "string.gsub" definition.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,7 @@
         "math": "disable",
         "os": "disable",
         "package": "disable",
-        "string": "disable",
+        "string": "enable",
         "table": "disable",
         "table.clear": "disable",
         "table.new": "disable",

--- a/config.json
+++ b/config.json
@@ -34,7 +34,7 @@
             "math": "disable",
             "os": "disable",
             "package": "disable",
-            "string": "disable",
+            "string": "enable",
             "table": "disable",
             "table.clear": "disable",
             "table.new": "disable",


### PR DESCRIPTION
I have a following code in Picotron project, which seems to work OK, but raises warnings in VS Code for `string.gsub` (or rather just `string`), because the related builtin is disabled:

```lua
---This function serves as a trick for an external editor:
---
---  - it's named `require`, which is a standard Lua function for
---     loading code from files, therefore it gets autocompletion etc.
---
---  - it uses Picotron's `include` under the hood
---
---@param modname string
function require(modname)
    local path = modname

    path = string.gsub(path, "%.", "/")
    path = string.gsub(path, "src/", "../../src/")
    path = path .. ".lua"

    include(path)
end
```
<img width="600" alt="screenshot 2025-10-02 at 12 06 21" src="https://github.com/user-attachments/assets/663bd905-2251-4373-b393-b2ebe1d77b53" />

Please be aware I am just replicating what works in my own Lua LSP config, and don't know if bringing in entire "string" module is corrct in context of Picotron.

---

Note: I do not use LLS-Addons. Instead, I have this repo checked out inside my project and referenced with:

```json
  "workspace.library": [
    "./lua-ls-addons/picotron/"
  ]
```

Then, I have a copy-paste of this repo's config file in my project's `.luarc.json`, with my own additions, e.g. enabled code formatter (although, for sake of creating this PR I commented out everything in my `.luarc.json` that was different from this project's config).
