### PR TITLE
Add initial naive definition of "create_process" and move things around in a file in order to make that definition really seen by LSP.

### DIFF
--- a/library/picotron.lua
+++ b/library/picotron.lua
@@ -15,6 +15,22 @@ function _update() end
 function _draw() end
 
 --------------------------------------------------------------------------------
+-- OS library functions
+--------------------------------------------------------------------------------
+
+---@param path string
+---@param options? {
+---  argv: string[],
+---}
+function create_process(path, options) end
+
+function notify(str) end
+
+function send_message(num, tbl) end
+
+function tostr(var) end
+
+--------------------------------------------------------------------------------
 -- Variables
 --------------------------------------------------------------------------------
 
@@ -25,13 +41,3 @@ metadata = {}
 
 ---@class delta
 delta = {}
-
---------------------------------------------------------------------------------
--- OS library functions
---------------------------------------------------------------------------------
-
-function notify(str) end
-
-function send_message(num, tbl) end
-
-function tostr(var) end


### PR DESCRIPTION
I have a following `appdata/system/startup.lua` in the mounted folder of my Picotron:

```lua
create_process("/system/util/load.lua", {
    argv = { "/desktop/ayp.p64" },
})

```

I wanted to have a basic support for `create_process`, therefore adding this PR.

Moreover, I realized for some reasons unknown for me, neither of other definitions from the bottom part of `library/picotron.lua` (e.g. `notify`) were recognized by LSP in my VS Code. But one I moved them above `_ENV` and other variable declarations, they became visible for LSP.