### PR TITLE
Add LSP warnings for unrecognized types by no longer disabling "undefined-doc-name" diagnostic.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
     "Lua.workspace.checkThirdParty": false,
     "Lua.diagnostics.disable": [
         "lowercase-global",
-        "undefined-doc-name",
         "err-esc"
     ],
     "Lua.runtime.nonstandardSymbol": [
@@ -23,7 +22,7 @@
         "basic": "disable",
         "bit": "disable",
         "bit32": "disable",
-        "builtin": "disable",
+        "builtin": "enable",
         "coroutine": "disable",
         "debug": "disable",
         "ffi": "disable",

--- a/config.json
+++ b/config.json
@@ -5,7 +5,6 @@
         "Lua.workspace.checkThirdParty": false,
         "Lua.diagnostics.disable": [
             "lowercase-global",
-            "undefined-doc-name",
             "err-esc"
         ],
         "Lua.runtime.nonstandardSymbol": [
@@ -25,7 +24,7 @@
             "basic": "disable",
             "bit": "disable",
             "bit32": "disable",
-            "builtin": "disable",
+            "builtin": "enable",
             "coroutine": "disable",
             "debug": "disable",
             "ffi": "disable",


### PR DESCRIPTION
If I set my project's `.luarc.json` to mimic this project's config, I can put any type in annotations and there is no warning, e.g. for the made up `foobar` type here:

<img width="300"  alt="screenshot 2025-10-02 at 13 06 50" src="https://github.com/user-attachments/assets/89a6728e-3a01-46fc-8996-15cfc68c3e12" />

So I remove `"undefined-doc-name"` disablement from the config and `foobar` is correctly spotted as "Undefined type or alias".

But then when I switch it to the correct `boolean`, I get an error, since `boolean` is also not defined. And I get tons of errors like that for all other type annotations referring to types like `boolean`, `number`, `string`, etc.

To fix that (or at least, to do something that seems to help with it), I enabled `builtin` runtime builtin in the config. With that, primitives are recognized and made up types like `foobar` are spotted as wrong.