### PR TITLE
Define "menuitem"

### DIFF
--- a/library/menu.lua
+++ b/library/menu.lua
@@ -1,0 +1,11 @@
+---@meta
+
+---Adds a custom item to the pause menu (invoked with the Enter key).
+---
+---There is no official documentation for `menuitem`, but there is a chance
+---it works similar to PICO-8 version ([view online](https://www.lexaloffle.com/dl/docs/pico-8_manual.html#MENUITEM)).
+---
+---@param index number The place in the menu where to put the new item.
+---@param label string
+---@param callback? fun(bitfield: number): boolean? A funtion to be calledwhen the item is selected by the user. Takesa a single argument that is a bitfield of button presses. If the callback returns true, the pause menu remains open.
+function menuitem(index, label, callback) end


### PR DESCRIPTION
The code which I uses to test this definition:

```lua
g = {
    _debug = false,
    -- rest of the table
}

function debug_menu_item_label()
    return "Debug: " .. (g._debug and "ON" or "OFF")
end

function _update()
    menuitem(1, debug_menu_item_label(), function ()
        g._debug = not g._debug
        menuitem(1, debug_menu_item_label())
        return true
    end)

   -- rest of the function
end
```

I also tried variants without `return` in the callback, with printing out the `bitmask` param of the callback, and without callback at all. Label seemed to be required to avoid a runtime error.