### PR TITLE
Enable "basic" builtin in order to provide "tostring" definition.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
         ">>="
     ],
     "Lua.runtime.builtin": {
-        "basic": "disable",
+        "basic": "enable",
         "bit": "disable",
         "bit32": "disable",
         "builtin": "disable",

--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
             ">>="
         ],
         "Lua.runtime.builtin": {
-            "basic": "disable",
+            "basic": "enable",
             "bit": "disable",
             "bit32": "disable",
             "builtin": "disable",


### PR DESCRIPTION
I have a following debug helper code in my Picotron project:

```lua
---@type string[]
local dbg_lines = {}

---@param val any
function dbg(val)
    add(dbg_lines, tostring(val))
end
```

With `runtime.builtin.basic` configured to `disable` I get a warning in VS Code:

```
Undefined global `tostring`.
```

<img width="600"  alt="screenshot 2025-10-02 at 11 51 53" src="https://github.com/user-attachments/assets/0168f0bb-494e-4366-9732-ce2405a2cd4b" />

Similar for `ipairs` in:

```lua
u = {}

u.adjacent_8 = {
    vec(-1, -1),
    vec(0, -1),
    vec(1, -1),
    vec(1, 0),
    vec(1, 1),
    vec(0, 1),
    vec(-1, 1),
    vec(-1, 0),
}

---@param text string
---@param x number
---@param y number
---@param text_color Color
---@param outline_color Color
function u.print_with_outline(text, x, y, text_color, outline_color)
    for _, offset in ipairs(u.adjacent_8) do
        print(text, x + offset.x, y + offset.y, outline_color)
    end
    print(text, x, y, text_color)
end
```

Also for `select` in:

```lua
original_print = print

-- This override enabled PICO-8 font for all printed texts
---@return number
print = function (...)
    local text = ...
    if text == nil then
        return original_print(text) --[[@as number]]
    end
    return original_print("\014" .. text, select(2, ...)) --[[@as number]]
end

```

---

Note: I do not use LLS-Addons. Instead, I have this repo checked out inside my project and referenced with:

```json
  "workspace.library": [
    "./lua-ls-addons/picotron/"
  ]
```

Then, I have a copy-paste of this repo's config file in my project's `.luarc.json`, with my own additions, e.g. enabled code formatter (although, for sake of creating this PR I commented out everything in my `.luarc.json` that was different from this project's config).

---

I am not sure if this PR is correct, I mean if it doesn't bring too much definitions into the table.
